### PR TITLE
correct sentence to use 'resources' word only once

### DIFF
--- a/tutorial/cloudshell_tutorial.md
+++ b/tutorial/cloudshell_tutorial.md
@@ -268,7 +268,7 @@ dependent on each resource provider and is fully documented within our
 [providers reference](https://www.terraform.io/docs/providers/index.html).
 
 The [GCP provider](https://www.terraform.io/docs/providers/google/index.html)
-documents supported resources resources, including
+documents supported resources, including
 [google_compute_network](https://www.terraform.io/docs/providers/google/r/compute_network.html).
 
 There are a number of optional arguments, but for our network, we just specify


### PR DESCRIPTION
In the following sentence
`The GCP provider documents supported resources resources, including google_compute_network.`
resource word is used twice. I have corrected the same, please have a look. Thanks